### PR TITLE
Added Data Persistence for both chat and editor and other features

### DIFF
--- a/collab-service/index.js
+++ b/collab-service/index.js
@@ -3,7 +3,6 @@ import cors from "cors";
 import { createServer } from "http";
 import { Server } from "socket.io";
 import "dotenv/config";
-import { SocketAddress } from "net";
 
 const router = express.Router();
 const app = express();
@@ -11,6 +10,9 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(cors({ origin: true, credentials: true })); // config cors so that front-end can use
 app.options("*", cors());
+
+const in_mem_storage_editor = new Map();
+const in_mem_storage_chat = new Map();
 
 let FRONTEND_URL = process.env.FRONTEND_URL;
 const http = createServer(app);
@@ -28,18 +30,30 @@ io.on("connection", (socket) => {
     log("Connected");
     var id = socket.handshake.query.id;
     socket.join(id);
+
+    if (in_mem_storage_editor.has(id)) {
+        socket.emit("editor", in_mem_storage_editor.get(id))
+    }
+    if (in_mem_storage_chat.has(id)) {
+        socket.emit("chat", in_mem_storage_chat.get(id))
+    }
     socket.on("editor", ({ content, to }) => {
+        in_mem_storage_editor.set(to,content)
         socket.to(to).emit("editor", content);
     });
     socket.on("chat", ({ message, to }) => {
+        in_mem_storage_chat.set(to, message)
         socket.to(to).emit("chat", message);
     });
-    socket.on("exit", ({ to }) => {
+    socket.on("exit", ({to}) => {
         socket.to(to).emit("exit");
     });
-});
-
-//disconnect
-io.on("disconnect", (evt) => {
-    log("User left");
+    socket.on("disconnect", (reason) => {
+        var rooms = io.sockets.adapter.rooms
+        //remove from storage once two users left the room.
+        if (!(rooms.get(id))) {
+            in_mem_storage_chat.delete(id);
+            in_mem_storage_editor.delete(id);
+        }
+   });
 });

--- a/collab-service/index.js
+++ b/collab-service/index.js
@@ -42,7 +42,11 @@ io.on("connection", (socket) => {
         socket.to(to).emit("editor", content);
     });
     socket.on("chat", ({ message, to }) => {
-        in_mem_storage_chat.set(to, message)
+        if (in_mem_storage_chat.get(to)) {
+            in_mem_storage_chat.set(to, in_mem_storage_chat.get(id) + "\n"+ message)
+        } else {
+            in_mem_storage_chat.set(to, message)
+        }
         socket.to(to).emit("chat", message);
     });
     socket.on("exit", ({to}) => {

--- a/frontend/src/pages/SessionPage.js
+++ b/frontend/src/pages/SessionPage.js
@@ -20,6 +20,8 @@ export default function SessionPage() {
     let socket;
     const location = useLocation();
     const navigate = useNavigate();
+    const username = location.state.username;
+    const topic = location.state.topic;
 
     const handleSession = useCallback(async () => {
         const sessionId = location.state.roomId;
@@ -51,9 +53,9 @@ export default function SessionPage() {
         chatfield.addEventListener("keypress", (evt) => {
             evt.preventDefault();
             if (evt.key === "Enter" && chatfield.value) {
-                updateChatbox("Me: " + chatfield.value);
+                updateChatbox(username+ ": " + chatfield.value);
                 socket.emit("chat", {
-                    message: chatfield.value,
+                    message: username+ ": " + chatfield.value,
                     to: sessionId,
                 });
                 chatfield.value = "";
@@ -66,8 +68,7 @@ export default function SessionPage() {
             editor.value = data;
         });
 
-        socket.on("chat", (data) => updateChatbox("=> Partner: " + data));
-
+        socket.on("chat", (data) => updateChatbox(data));
         socket.on("exit", () => updateChatbox("Partner left session"));
     }, [location, navigate]);
 
@@ -113,10 +114,10 @@ export default function SessionPage() {
                 >
                     <Box margin="0.25em">
                         <Typography fontSize="0.35em" fontFamily="Lato">
-                            Difficulty:
+                            Difficulty: {location.state.difficultyLevel}
                         </Typography>
                         <Typography fontSize="0.35em" fontFamily="Lato">
-                            Topic:
+                            Topic: {location.state.topic}
                         </Typography>
                         <Typography fontSize="0.35em" fontFamily="Lato">
                             Question: {location.state.question}

--- a/frontend/src/pages/WaitingPage.js
+++ b/frontend/src/pages/WaitingPage.js
@@ -90,6 +90,11 @@ export default function WaitingPage() {
                     state: {
                         roomId,
                         question,
+                        difficultyLevel: DIFFICULTY_LEVELS.find(
+                            (item) => item.value === difficultyLevel
+                        ).label,
+                        topic: TOPICS.find((item) => item.value === topic)
+                        .label,
                         email,
                         username,
                         isInviteMatched,


### PR DESCRIPTION
Data stays persistent when refreshing page. Shows topic and difficulty level in the session page. Changed chatbox to show usernames instead.

Rationale: Content in chatbox differs between client. Thus we change the chatbox to instead display their usernames, thus guaranteeing the content is always the same.